### PR TITLE
Security fix for prototype pollution in js-ini

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export function parse(data: string, params?: IParseConfig): IIniObject {
         if (!(currentSection in result)) {
           result[currentSection] = (isDataSection) ? [] : {};
         }
-        if (currentSection == '__proto__')
+        if (currentSection == '__proto__' || currentSection == 'constructor' || currentSection == 'prototype')
           break;
         continue;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,8 +71,7 @@ export function parse(data: string, params?: IParseConfig): IIniObject {
         if (!(currentSection in result)) {
           result[currentSection] = (isDataSection) ? [] : {};
         }
-        if (currentSection == '__proto__' || currentSection == 'constructor' || currentSection == 'prototype')
-          break;
+        if(isPrototypePolluted(currentSection)) break;
         continue;
       }
     } else if (isDataSection) {
@@ -166,6 +165,10 @@ export function stringify(data: IIniObject, params?: IStringifyConfig): string {
     curKeyId = 0;
   }
   return chunks.join('\n');
+}
+
+function isPrototypePolluted(key: any) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key);
 }
 
 export const decode = parse;

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,8 @@ export function parse(data: string, params?: IParseConfig): IIniObject {
         if (!(currentSection in result)) {
           result[currentSection] = (isDataSection) ? [] : {};
         }
+        if (currentSection == '__proto__')
+          break;
         continue;
       }
     } else if (isDataSection) {


### PR DESCRIPTION
### 📊 Metadata *

`js-ini` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-js-ini

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Prototype pollution if fixed by not allowing to modify object prototype.

### 🐛 Proof of Concept (PoC)

1. Create the following PoC and INI files:
```javascript
// poc.js
var fs = require('fs')
var ini = require('js-ini')
console.log("Before : " + {}.polluted);
var parsed = ini.parse(fs.readFileSync('./payload.ini', 'utf-8'))
console.log("After : " + {}.polluted);

//payload.ini
[__proto__]
polluted = "Yes! Its Polluted"
```
2. Execute the following commands in terminal:
```bash
npm i js-ini # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : "Yes! Its Polluted"
```

### 🔥 Proof of Fix (PoF) *

Prototype pollution is fixed as seen below.

![pof](https://raw.githubusercontent.com/arjunshibu/files/main/js-ini-fix.png)

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/43996156/103257017-7d001e00-49b5-11eb-9a91-d96f4497a7d5.png)

* I've executed unit tests
* After fix the functionality is unaffected.
